### PR TITLE
include a license file in wheels

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[metadata]
+license-file = LICENSE-MIT


### PR DESCRIPTION
This includes `LICENSE-MIT` in wheels; this makes it easier for redistributors to follow the terms of your license. (You might want to instead make a single file that includes both the Apache and MIT licenses, if you preferred....)